### PR TITLE
feat: add hacky version of UsersGuard

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -2,11 +2,12 @@ import { NgModule } from '@angular/core'
 import { Routes, RouterModule } from '@angular/router'
 import { LoginComponent } from './auth/login/login.component'
 import { UsersComponent } from './users/users.component'
+import { UsersGuard } from './users/users-guard.service'
 
 const routes: Routes = [
   { path: '', component: LoginComponent },
   { path: 'login', component: LoginComponent },
-  { path: 'users', component: UsersComponent }
+  { path: 'users', component: UsersComponent, canActivate: [ UsersGuard ] }
 ]
 
 @NgModule({

--- a/src/app/users/users-guard.service.ts
+++ b/src/app/users/users-guard.service.ts
@@ -1,0 +1,20 @@
+import { CanActivate, Router } from '@angular/router'
+import { Injectable } from '@angular/core'
+
+import { AuthService } from '../auth/auth.service'
+
+@Injectable()
+export class UsersGuard implements CanActivate {
+  constructor(private router: Router, private auth: AuthService) {}
+
+  canActivate() {
+    // TODO: Figure out how to do this with userIdentity$ stream instead of getUserFromStoredToken()
+    const user = this.auth.getUserFromStoredToken()
+    if (user && user.isAdmin()) {
+      return true
+    } else {
+      this.router.navigate(['login'])
+      return false
+    }
+  }
+}

--- a/src/app/users/users.module.ts
+++ b/src/app/users/users.module.ts
@@ -2,6 +2,7 @@ import { NgModule } from '@angular/core'
 
 import { UsersComponent } from './users.component'
 import { SharedModule } from '../shared/shared.module'
+import { UsersGuard } from './users-guard.service'
 
 @NgModule({
   declarations: [
@@ -9,6 +10,9 @@ import { SharedModule } from '../shared/shared.module'
   ],
   imports: [
     SharedModule
+  ],
+  providers: [
+    UsersGuard
   ]
 })
 export class UsersModule {


### PR DESCRIPTION
- Would like to do this without calling getUserFromStoredToken() at some point
- Instead, would like to subscribe to userIdentity$, but Angular says that's not properly implementing the CanActivate interface
- This works to kick any non-admin user to /login.